### PR TITLE
Add license to gemspec.

### DIFF
--- a/redis.gemspec
+++ b/redis.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   ]
 
   s.email = ["redis-db@googlegroups.com"]
-
+  s.license = "MIT"
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com/ruby/redis/) and for us the license information is very important. It would be extremely helpful if this information would be available in the gemspec. Many thanks. Robert.
