### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # <span style='color: red; font-size: 2em'>REPO MOVED</span>
 
-<span style='font-size: 2em'>
 [https://github.com/redis/redis-rb](https://github.com/redis/redis-rb)
-</span>
 


### PR DESCRIPTION
This fixes the link to the new repo. 

Before this change it was trying to display a markdown inside a HTML and the link did not worked.

<img width="1252" alt="image" src="https://github.com/ezmobius/redis-rb/assets/1407869/5ec50bd3-b961-43d1-a2b8-6d4edabc0380">


